### PR TITLE
Changed way of including Catch2

### DIFF
--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.26)
 
 project(playground)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 add_subdirectory(src/business_logic/bus_stop)

--- a/tests/unit.tests/business_logic/bus_stop/CMakelists.txt
+++ b/tests/unit.tests/business_logic/bus_stop/CMakelists.txt
@@ -1,8 +1,16 @@
 project(bus_stop_functions_business_logic_unit_test)
 
-add_subdirectory(../../../../lib/Catch2 build)
-
 add_executable(bus_stop_functions_business_logic_unit_test main_bus_stop.cpp)
+
+Include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.0.1
+)
+
+FetchContent_MakeAvailable(Catch2)
 
 target_link_libraries(bus_stop_functions_business_logic_unit_test PRIVATE Catch2::Catch2WithMain)
 


### PR DESCRIPTION
Used fetch content to include Catch2 Except manually cloning library from Git